### PR TITLE
Fix insecure option in OTLPLogExporter

### DIFF
--- a/otlp_exporter/handler.py
+++ b/otlp_exporter/handler.py
@@ -39,7 +39,7 @@ class DirectWriteLoggingHandler(LoggingHandler):
 
         exporter = OTLPLogExporter(
             endpoint=configs["endpoint"],
-            insecure=configs["is_secure"],
+            insecure=not configs["is_secure"],
         )
         log_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
 


### PR DESCRIPTION
This library exposes is_secure option but the OTLPLogExporter uses insecure. So, we need to invert the value before sending to OTLPLogExporter class.